### PR TITLE
Fix link to CSS file in subfolder

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" type="text/css" href="/static/index.css" />
+  <link rel="stylesheet" type="text/css" href="static/index.css" />
 </head>
 
 <body>


### PR DESCRIPTION
Hi there! When downloading the project, it does not load properly because the link to the 'static' subfolder is incorrect. This pull request fixes this.